### PR TITLE
Jackmoody11/json decode error

### DIFF
--- a/secedgar/tests/core/test_company.py
+++ b/secedgar/tests/core/test_company.py
@@ -235,15 +235,16 @@ class TestCompanyFilings:
 
     @pytest.mark.smoke
     def test_no_json_decode_error(self, real_test_client):
-        from secedgar import CompanyFilings, FilingType
         from json import JSONDecodeError
+
+        from secedgar import CompanyFilings, FilingType
 
         my_filings = CompanyFilings(cik_lookup='aapl',
                                     filing_type=FilingType.FILING_10Q,
                                     count=15,
                                     user_agent=real_test_client)
         try:
-            res = my_filings.get_urls()
+            my_filings.get_urls()
         except JSONDecodeError:
             pytest.fail("Received JSONDecodeError")
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/whatsnew latest version

## Summary by Sourcery

Add a smoke test to verify that fetching URLs for company filings does not raise a JSONDecodeError, ensuring robustness in handling JSON responses.

Bug Fixes:
- Add a test to ensure no JSONDecodeError is raised when fetching URLs for company filings.

Tests:
- Introduce a smoke test to verify that fetching URLs for company filings does not raise a JSONDecodeError.